### PR TITLE
Fix link to Dockerfile, add Instructions to run without docker compose

### DIFF
--- a/_docs/install-and-upgrade.md
+++ b/_docs/install-and-upgrade.md
@@ -48,6 +48,7 @@ Creating filestash_app ... done
 
 *Note*: The Docker Compose command above will run Filestash as well as OnlyOffice Document Server. Please check the requirements here: https://hub.docker.com/r/onlyoffice/documentserver#recommended-system-requirements
 
+=======
 Once the installation has complete, open up a browser and navigate to: `http://your_ip:8334`, you will be greet with the setup screen:
 
 <img src="https://raw.githubusercontent.com/mickael-kerjean/filestash_images/master/screenshots/setup.png" alt="setup screenshot" height="320px"/>

--- a/_docs/install-and-upgrade.md
+++ b/_docs/install-and-upgrade.md
@@ -48,7 +48,7 @@ Creating filestash_app ... done
 
 *Note*: The Docker Compose command above will run Filestash as well as OnlyOffice Document Server. Please check the requirements here: https://hub.docker.com/r/onlyoffice/documentserver#recommended-system-requirements
 
-Once the installation has complete, open up a browser and navigate to: `http://your_ip:8334`, you will be greet with the configurator:
+Once the installation has complete, open up a browser and navigate to: `http://your_ip:8334`, you will be greet with the setup screen:
 
 <img src="https://raw.githubusercontent.com/mickael-kerjean/filestash_images/master/screenshots/setup.png" alt="setup screenshot" height="320px"/>
 Enter the admin password you want to use to protect the admin console that's available under `/admin`.

--- a/_docs/install-and-upgrade.md
+++ b/_docs/install-and-upgrade.md
@@ -112,9 +112,15 @@ In the meantime, community supported guides are also available:
 
 If you want to install Filestash on your own with a more custom build approach, the reference is the [Dockerfile](https://github.com/mickael-kerjean/filestash/blob/master/docker/Dockerfile){:rel="nofollow"}. This recipe is just 1 example of a custom compilation that emphasis on speed, efficiency and features at the cost of installation size. You could shrink down the required space by 90% by disabling features such as image transcoding (getting rid of libvips and libraw), org-mode export (getting rid of emacs and our latex distribution) and other tools (such as pdftotext, ...)
 
-The easiest way to run Filestash without Docker Compose is to use the following Docker command:
-
-`docker run -d -p 8443:8443 -v $pwd:/app/data/state/ -e APPLICATION_URL=example.com machines/filestash`
+The easiest way to run Filestash without Docker Compose is to use the following steps:
+```
+mkdir -p /srv/filestash/{log,config}
+touch /srv/filestash/log/access.log
+chmod 0777 /srv/filestash/log/access.log
+touch /srv/filestash/config/config.json
+chmod 0777 /srv/filestash/config/config.json
+docker run -d -p 8443:8443 -v /srv/filestash:/app/data/state -e APPLICATION_URL=example.com machines/filestash
+```
 
 ## Optional: Using a reverse proxy
 

--- a/_docs/install-and-upgrade.md
+++ b/_docs/install-and-upgrade.md
@@ -112,6 +112,10 @@ In the meantime, community supported guides are also available:
 
 If you want to install Filestash on your own with a more custom build approach, the reference is the [Dockerfile](https://github.com/mickael-kerjean/filestash/blob/master/docker/Dockerfile){:rel="nofollow"}. This recipe is just 1 example of a custom compilation that emphasis on speed, efficiency and features at the cost of installation size. You could shrink down the required space by 90% by disabling features such as image transcoding (getting rid of libvips and libraw), org-mode export (getting rid of emacs and our latex distribution) and other tools (such as pdftotext, ...)
 
+The easiest way to run Filestash without Docker Compose is to use the following Docker command:
+
+`docker run -d -p 8443:8443 -v $pwd:/app/data/state/ -e APPLICATION_URL=example.com machines/filestash`
+
 ## Optional: Using a reverse proxy
 
 Using a reverse proxy isn't mandatory but is quite usefull when you have multiple things installed on your server and can't dedicate the port 80 and 443 to 1 application.

--- a/_docs/install-and-upgrade.md
+++ b/_docs/install-and-upgrade.md
@@ -114,9 +114,7 @@ If you want to install Filestash on your own with a more custom build approach, 
 
 The easiest way to run Filestash without Docker Compose is to use the following steps:
 ```
-mkdir -p /srv/filestash/{log,config}
-touch /srv/filestash/log/access.log
-chmod 0777 /srv/filestash/log/access.log
+mkdir -p /srv/filestash/{db,config}
 touch /srv/filestash/config/config.json
 chmod 0777 /srv/filestash/config/config.json
 docker run -d -p 8443:8443 -v /srv/filestash:/app/data/state -e APPLICATION_URL=example.com machines/filestash

--- a/_docs/install-and-upgrade.md
+++ b/_docs/install-and-upgrade.md
@@ -110,7 +110,7 @@ In the meantime, community supported guides are also available:
 - SRugina: [ubuntu instructions + script](https://github.com/mickael-kerjean/filestash/pull/136)
 - *add your own with a PR*
 
-If you want to install Filestash on your own with a more custom build approach, the reference is the [Dockerfile](https://github.com/mickael-kerjean/filestash/blob/master/docker/prod/Dockerfile){:rel="nofollow"}. This recipe is just 1 example of a custom compilation that emphasis on speed, efficiency and features at the cost of installation size. You could shrink down the required space by 90% by disabling features such as image transcoding (getting rid of libvips and libraw), org-mode export (getting rid of emacs and our latex distribution) and other tools (such as pdftotext, ...)
+If you want to install Filestash on your own with a more custom build approach, the reference is the [Dockerfile](https://github.com/mickael-kerjean/filestash/blob/master/docker/Dockerfile){:rel="nofollow"}. This recipe is just 1 example of a custom compilation that emphasis on speed, efficiency and features at the cost of installation size. You could shrink down the required space by 90% by disabling features such as image transcoding (getting rid of libvips and libraw), org-mode export (getting rid of emacs and our latex distribution) and other tools (such as pdftotext, ...)
 
 ## Optional: Using a reverse proxy
 

--- a/_docs/install-and-upgrade.md
+++ b/_docs/install-and-upgrade.md
@@ -46,6 +46,8 @@ Creating filestash_app ... done
 
 *Note*: Official Docker images are made available on [DockerHub](https://hub.docker.com/r/machines/filestash/).
 
+*Note*: The Docker Compose command above will run Filestash as well as OnlyOffice Document Server. Please check the requirements here: https://hub.docker.com/r/onlyoffice/documentserver#recommended-system-requirements
+
 Once the installation has complete, open up a browser and navigate to: `http://your_ip:8334`, you will be greet with the configurator:
 
 <img src="https://raw.githubusercontent.com/mickael-kerjean/filestash_images/master/screenshots/setup.png" alt="setup screenshot" height="320px"/>
@@ -112,12 +114,12 @@ In the meantime, community supported guides are also available:
 
 If you want to install Filestash on your own with a more custom build approach, the reference is the [Dockerfile](https://github.com/mickael-kerjean/filestash/blob/master/docker/Dockerfile){:rel="nofollow"}. This recipe is just 1 example of a custom compilation that emphasis on speed, efficiency and features at the cost of installation size. You could shrink down the required space by 90% by disabling features such as image transcoding (getting rid of libvips and libraw), org-mode export (getting rid of emacs and our latex distribution) and other tools (such as pdftotext, ...)
 
-The easiest way to run Filestash without Docker Compose is to use the following steps:
+Docker Compose will run Filestash as well as the OnlyOffice integration. Since the OnlyOffice Image needs at least 4GB RAM (as per https://hub.docker.com/r/onlyoffice/documentserver#recommended-system-requirements), you may want to run Filestash without Docker Compose. The easiest way to run Filestash without Docker Compose is to use the following steps:
 <div class="terminal">
-<span class="prompt">~/$ </span>mkdir -p /srv/filestash/{db,config}<br>
+<span class="prompt">~/$ </span>mkdir -p /srv/filestash/config<br>
 <span class="prompt">~/$ </span>touch /srv/filestash/config/config.json<br>
 <span class="prompt">~/$ </span>chmod 0777 /srv/filestash/config/config.json<br>
-<span class="prompt">~/$ </span>docker run -d -p 8443:8443 -v /srv/filestash/config:/app/data/state/config -v /srv/filestash/db:/app/data/state/db -e APPLICATION_URL=example.com machines/filestash
+<span class="prompt">~/$ </span>docker run -d -p 8443:8443 -v /srv/filestash/config/config.json:/app/data/state/config/config.json -e APPLICATION_URL=example.com machines/filestash
 </div>
 
 ## Optional: Using a reverse proxy

--- a/_docs/install-and-upgrade.md
+++ b/_docs/install-and-upgrade.md
@@ -48,8 +48,7 @@ Creating filestash_app ... done
 
 *Note*: The Docker Compose command above will run Filestash as well as OnlyOffice Document Server. Please check the requirements here: https://hub.docker.com/r/onlyoffice/documentserver#recommended-system-requirements
 
-=======
-Once the installation has complete, open up a browser and navigate to: `http://your_ip:8334`, you will be greet with the setup screen:
+Once the installation is completed, open up a browser and navigate to: `http://your_ip:8334`, you will be greet with the setup screen:
 
 <img src="https://raw.githubusercontent.com/mickael-kerjean/filestash_images/master/screenshots/setup.png" alt="setup screenshot" height="320px"/>
 Enter the admin password you want to use to protect the admin console that's available under `/admin`.

--- a/_docs/install-and-upgrade.md
+++ b/_docs/install-and-upgrade.md
@@ -117,7 +117,11 @@ The easiest way to run Filestash without Docker Compose is to use the following 
 mkdir -p /srv/filestash/{db,config}
 touch /srv/filestash/config/config.json
 chmod 0777 /srv/filestash/config/config.json
-docker run -d -p 8443:8443 -v /srv/filestash:/app/data/state -e APPLICATION_URL=example.com machines/filestash
+docker run -d -p 8443:8443 \
+    -v /srv/filestash/config:/app/data/state/config \
+    -v /srv/filestash/db:/app/data/state/db \
+    -e APPLICATION_URL=example.com \
+    machines/filestash
 ```
 
 ## Optional: Using a reverse proxy

--- a/_docs/install-and-upgrade.md
+++ b/_docs/install-and-upgrade.md
@@ -113,16 +113,12 @@ In the meantime, community supported guides are also available:
 If you want to install Filestash on your own with a more custom build approach, the reference is the [Dockerfile](https://github.com/mickael-kerjean/filestash/blob/master/docker/Dockerfile){:rel="nofollow"}. This recipe is just 1 example of a custom compilation that emphasis on speed, efficiency and features at the cost of installation size. You could shrink down the required space by 90% by disabling features such as image transcoding (getting rid of libvips and libraw), org-mode export (getting rid of emacs and our latex distribution) and other tools (such as pdftotext, ...)
 
 The easiest way to run Filestash without Docker Compose is to use the following steps:
-```
-mkdir -p /srv/filestash/{db,config}
-touch /srv/filestash/config/config.json
-chmod 0777 /srv/filestash/config/config.json
-docker run -d -p 8443:8443 \
-    -v /srv/filestash/config:/app/data/state/config \
-    -v /srv/filestash/db:/app/data/state/db \
-    -e APPLICATION_URL=example.com \
-    machines/filestash
-```
+<div class="terminal">
+<span class="prompt">~/$ </span>mkdir -p /srv/filestash/{db,config}<br>
+<span class="prompt">~/$ </span>touch /srv/filestash/config/config.json<br>
+<span class="prompt">~/$ </span>chmod 0777 /srv/filestash/config/config.json<br>
+<span class="prompt">~/$ </span>docker run -d -p 8443:8443 -v /srv/filestash/config:/app/data/state/config -v /srv/filestash/db:/app/data/state/db -e APPLICATION_URL=example.com machines/filestash
+</div>
 
 ## Optional: Using a reverse proxy
 


### PR DESCRIPTION
The link to the Dockfile in the main repository was brocken, this has been fixed

I also added instructions on how to run filestash without docker compose. Should I add notes, that this is only necessary when you want to have backups of the Filestash config, since you included the `VOLUME` instruction in the Dockerfile?